### PR TITLE
Fix: agda-cli show full path of imports

### DIFF
--- a/agda-cli.js
+++ b/agda-cli.js
@@ -8,6 +8,17 @@ const path = require("path");
 const command = process.argv[2];
 const filePath = process.argv[3];
 
+function simplifyAgdaOutput(output) {
+  // Regular expression to match module paths
+  const modulePathRegex = /([A-Za-z0-9]+\.)+([A-Za-z0-9]+)/g;
+  
+  // Replace full module paths with just the last part
+  return output.replace(modulePathRegex, (match) => {
+    const parts = match.split('.');
+    return parts[parts.length - 1];
+  });
+}
+
 // Execute an Agda command and return the output as a Promise
 function executeAgdaCommand(command) {
   return new Promise((resolve, reject) => {
@@ -143,7 +154,7 @@ function formatHoleInfo(hole, fileContent) {
   
   result += `${dim}${underline}${filePath}${reset}\n`;
   result += highlightCode(fileContent, hole.range.start.line, hole.range.start.col, hole.range.end.col - 1, hole.range.start.line, 'green');
-  return result;
+  return simplifyAgdaOutput(result);
 }
 
 // Formats error information for pretty printing
@@ -303,7 +314,7 @@ function prettyPrintOutput(out) {
   if (hasError) {
     console.error(prettyOut.trim());
   } else {
-    console.log(prettyOut.trim() || "Checked.");
+    console.log(simplifyAgdaOutput(prettyOut.trim()) || "Checked.");
   }
 }
 
@@ -312,7 +323,7 @@ function parseRunOutput(output) {
   const jsonObjects = parseJsonObjects(output);
   for (let obj of jsonObjects) {
     if (obj.kind === 'DisplayInfo' && obj.info && obj.info.kind === 'NormalForm') {
-      return obj.info.expr;
+      return simplifyAgdaOutput(obj.info.expr);
     }
   }
   return "No output";


### PR DESCRIPTION
This fixes the issue described here: https://github.com/HigherOrderCO/monobook/issues/32

As I did not found an official option from agda's compiler / cli process, the way out was to parse out the full path and only show the object name.

Example before fix:
![image](https://github.com/user-attachments/assets/1a5d7993-4d11-4a7f-9a70-5930be43aff2)

Fixed example:
![image](https://github.com/user-attachments/assets/84483a50-d66f-4293-be0e-8d25a161fe3e)
